### PR TITLE
feat: Improvement Board → Kanban Designer deep-link integration (#7)

### DIFF
--- a/.artefacts/BRIEF.md
+++ b/.artefacts/BRIEF.md
@@ -20,7 +20,7 @@ Team improvement tracking aligned with Management 3.0 Improvement Dialogues / Co
 
 <!-- Research issues (`needs-review`) — agent appends after stable research runs -->
 - [x] [#3] Feature: Export board snapshot as PNG for stakeholder reporting
-- [ ] [#7] Integration: link Improvement Board items to Kanban Designer
+- [x] [#7] Integration: link Improvement Board items to Kanban Designer
 - [ ] [#8] Feature: team priority voting on improvement items
 - [ ] [#9] Research: keyboard accessibility and ARIA audit for board views
 - [x] [#10] Integration: Dashboard card via improvement-board:lastSession localStorage key
@@ -46,6 +46,12 @@ Team improvement tracking aligned with Management 3.0 Improvement Dialogues / Co
 - Re-run literal-key audit after large copy changes; keep `ru.json` in sync with `en.json`.
 
 ## Agent Log
+
+### 2026-06-03 — feat: Improvement Board → Kanban Designer deep-link (#7)
+- Done: added `src/utils/kanbanLink.ts` with `buildKanbanUrl()` — serialises all items into KanbanBoard prefill JSON (columns: Identified/In Progress/Done, cards: title + description) and builds `https://agile-toolkit.github.io/kanban-designer/?prefill=<json>&utm_source=improvement-board`; added "Open in Kanban Designer" `<a>` button in `BoardView.tsx` and `ImprovementBoard.tsx` (Kanban view) headers; i18n keys `board.open_kanban_designer` and `board.open_kanban_designer_title` added to EN/ES/BE/RU; Kanban Designer prefill receiving side to be implemented in a kanban-designer run
+- Marked issue #7 as In Review
+- Remaining approved issues: #8, #9, #14, #15, #16
+- Next task: implement #14 (Sprint cycle reset — archive done items with sprint summary; add "End Sprint" button in Board view, archive done items to localStorage key improvement-board:sprintHistory, show sprint count badge, clear done column, i18n keys in EN/ES/BE/RU)
 
 ### 2026-05-30 — feat: Export board snapshot as PNG (#3)
 - Done: installed `html2canvas`; added `handleExport` in `BoardView.tsx` and `ImprovementBoard.tsx` (Kanban); "Export PNG" button in both view headers; html2canvas captures the columns grid; clipboard write attempted first, falls back to `improvement-board-YYYY-MM-DD.png` download; busy/done toast with 2 s auto-reset; i18n keys `board.export_png`, `board.export_downloading`, `board.export_copied` added to EN/ES/BE/RU

--- a/src/components/BoardView.tsx
+++ b/src/components/BoardView.tsx
@@ -4,6 +4,7 @@ import html2canvas from 'html2canvas'
 import type { ImprovementItem, ImprovementStatus } from '../types'
 import ImprovementCard from './ImprovementCard'
 import AddItemModal from './AddItemModal'
+import { buildKanbanUrl } from '../utils/kanbanLink'
 
 const COLUMNS: ImprovementStatus[] = ['identified', 'in_progress', 'done']
 const SPRINT_METRICS_URL = 'https://agile-toolkit.github.io/sprint-metrics/'
@@ -120,6 +121,15 @@ export default function BoardView({ items, onAdd, onUpdate, onDelete, onDialogue
               {t('board.sort_stale_first')}
             </button>
           </div>
+          <a
+            href={buildKanbanUrl(items)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn-secondary text-xs"
+            title={t('board.open_kanban_designer_title')}
+          >
+            {t('board.open_kanban_designer')}
+          </a>
           <button
             onClick={handleExport}
             disabled={exportState === 'busy'}

--- a/src/components/ImprovementBoard.tsx
+++ b/src/components/ImprovementBoard.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import html2canvas from 'html2canvas'
 import type { ImprovementItem, TeamMember, Category, ImprovementStatus } from '../types'
 import { getDueDateState, dueBadgeClasses, formatDueDate, getAgeState, ageDaysOld } from '../utils/dueDate'
+import { buildKanbanUrl } from '../utils/kanbanLink'
 
 interface Props {
   items: ImprovementItem[]
@@ -156,6 +157,15 @@ export default function ImprovementBoard({ items, members, onItems }: Props) {
               {t('board.sort_stale_first')}
             </button>
           </div>
+          <a
+            href={buildKanbanUrl(items)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="border border-gray-200 text-gray-600 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors"
+            title={t('board.open_kanban_designer_title')}
+          >
+            {t('board.open_kanban_designer')}
+          </a>
           <button
             type="button"
             onClick={handleExport}

--- a/src/i18n/be.json
+++ b/src/i18n/be.json
@@ -63,7 +63,9 @@
     "age_stale_tooltip": "Апошняе абнаўленне {{days}} дзён таму (застарэлы)",
     "export_png": "Экспарт PNG",
     "export_downloading": "Экспарт…",
-    "export_copied": "Захавана!"
+    "export_copied": "Захавана!",
+    "open_kanban_designer": "Адкрыць у Kanban Designer",
+    "open_kanban_designer_title": "Адкрыць усе элементы ў Kanban Designer (новая ўкладка)"
   },
   "add_form": {
     "title": "Новы Элемент Паляпшэння",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -63,7 +63,9 @@
     "age_stale_tooltip": "Last updated {{days}} days ago (stale)",
     "export_png": "Export PNG",
     "export_downloading": "Exporting…",
-    "export_copied": "Saved!"
+    "export_copied": "Saved!",
+    "open_kanban_designer": "Open in Kanban Designer",
+    "open_kanban_designer_title": "Open all items in Kanban Designer (opens in new tab)"
   },
   "add_form": {
     "title": "New Improvement Item",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -63,7 +63,9 @@
     "age_stale_tooltip": "Actualizado hace {{days}} días (estancado)",
     "export_png": "Exportar PNG",
     "export_downloading": "Exportando…",
-    "export_copied": "¡Guardado!"
+    "export_copied": "¡Guardado!",
+    "open_kanban_designer": "Abrir en Kanban Designer",
+    "open_kanban_designer_title": "Abrir todos los elementos en Kanban Designer (nueva pestaña)"
   },
   "add_form": {
     "title": "Nuevo Ítem de Mejora",

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -63,7 +63,9 @@
     "age_stale_tooltip": "Последнее обновление {{days}} дней назад (застрявший)",
     "export_png": "Экспорт PNG",
     "export_downloading": "Экспорт…",
-    "export_copied": "Сохранено!"
+    "export_copied": "Сохранено!",
+    "open_kanban_designer": "Открыть в Kanban Designer",
+    "open_kanban_designer_title": "Открыть все элементы в Kanban Designer (новая вкладка)"
   },
   "add_form": {
     "title": "Новый элемент улучшения",

--- a/src/utils/kanbanLink.ts
+++ b/src/utils/kanbanLink.ts
@@ -1,0 +1,40 @@
+import type { ImprovementItem, ImprovementStatus } from '../types'
+
+const KANBAN_DESIGNER_URL = 'https://agile-toolkit.github.io/kanban-designer/'
+
+const STATUS_COLUMN_NAMES: Record<ImprovementStatus, string> = {
+  identified: 'Identified',
+  in_progress: 'In Progress',
+  done: 'Done',
+}
+
+export function buildKanbanUrl(items: ImprovementItem[]): string {
+  const columns = (['identified', 'in_progress', 'done'] as ImprovementStatus[]).map(status => ({
+    id: status,
+    name: STATUS_COLUMN_NAMES[status],
+    wipLimit: null,
+    cards: items
+      .filter(i => i.status === status)
+      .map(i => ({
+        id: i.id,
+        title: i.title,
+        description: i.description || undefined,
+      })),
+    subColumns: [],
+  }))
+
+  const board = {
+    id: crypto.randomUUID(),
+    name: 'Improvement Board',
+    columns,
+    swimLanes: [],
+    showWipWarnings: false,
+  }
+
+  const params = new URLSearchParams({
+    prefill: JSON.stringify(board),
+    utm_source: 'improvement-board',
+  })
+
+  return `${KANBAN_DESIGNER_URL}?${params.toString()}`
+}


### PR DESCRIPTION
Automated agent commit — see BRIEF.md.

Adds an **Open in Kanban Designer** button to both the Board and Kanban view headers. Clicking it serialises all current improvement items into a KanbanBoard prefill JSON and opens Kanban Designer in a new tab with the URL param `?prefill=<json>&utm_source=improvement-board`.

**Column mapping:** Identified → Identified, In Progress → In Progress, Done → Done.

**Note:** The Kanban Designer receiving side (reading the `?prefill` param) will be implemented in a subsequent kanban-designer run.

i18n: EN/ES/BE/RU